### PR TITLE
updated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - ReleaseDate
+### Fixed
+* arg_for_option/1 function in FFmpex module to not sue sigil `~w` which will turn every word in a separate argument, instead it will now return the argument as is
+
 ## 0.10.0 (2022-01-14)
 
 * Allow FFprobe on remote URLs, instead of treating URLs as nonexistent files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - ReleaseDate
+### Added
+* `-hide_banner` option 
+    https://ffmpeg.org/ffmpeg.html#Generic-options
+
+    Suppress printing banner.
+
+    All FFmpeg tools will normally show a copyright notice, build options and library versions. This option can be used to suppress printing this information.
+
+
 ### Fixed
 * arg_for_option/1 function in FFmpex module to not sue sigil `~w` which will turn every word in a separate argument, instead it will now return the argument as is
 

--- a/lib/ffmpex.ex
+++ b/lib/ffmpex.ex
@@ -185,7 +185,7 @@ defmodule FFmpex do
     ~w(#{name})
   end
   defp arg_for_option(%Option{name: name, argument: arg}) when not is_nil(arg) do
-    ~w(#{name} #{arg})
+    [name, arg]
   end
 
   defp validate_contexts!(:unspecified, _), do: :ok

--- a/lib/ffmpex/options/main.ex
+++ b/lib/ffmpex/options/main.ex
@@ -52,7 +52,8 @@ defmodule FFmpex.Options.Main do
     segment_time:         %Option{name: "-segment_time", require_arg: true, contexts: [:input, :output]},
     segment_list:         %Option{name: "-segment_list", require_arg: true, contexts: [:input, :output]},
     mux_preload:          %Option{name: "-muxpreload", require_arg: true, contexts: [:input, :output]},
-    mux_delay:            %Option{name: "-muxdelay", require_arg: true, contexts: [:input, :output]}
+    mux_delay:            %Option{name: "-muxdelay", require_arg: true, contexts: [:input, :output]},
+    hide_banner:          %Option{name: "-hide_banner", contexts: [:global]},
   }
 
   require FFmpex.Options.Helpers


### PR DESCRIPTION
## [Unreleased] - ReleaseDate
### Fixed
* arg_for_option/1 function in FFmpex module to not sue sigil `~w` which will turn every word in a separate argument, instead it will now return the argument as is